### PR TITLE
Changing Build to Use a Prefix (And Fixing VSTS Build Issues)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,3 +290,11 @@ __pycache__/
 *.xsd.cs
 src/Web/content-reactor/wwwroot/dist/bundle.js
 /web/src/signalr-web/SignalRMiddleware/EventApp/.vscode/launch.json
+/.azure
+/.config/configstore
+/.dotnet
+/.node-gyp/8.11.3
+/.npm
+/.nuget/NuGet
+/proxy/proxies/proxies.zip
+/web/src/signalr-web/SignalRMiddleware/SignalRMiddleware/wwwroot

--- a/setup.md
+++ b/setup.md
@@ -357,7 +357,7 @@ The web app is deployed into its own resource group. It has its own ARM template
 
  2. **Deploy ARM Template:** Use the _Azure Resource Group Deployment_ task, with the _Action_ set to `Create or update resource group`. Set the _Template_ to the location of the `template.json` file, e.g. `$(System.DefaultWorkingDirectory)/web/deploy/template.json`. Set the _Overridable template parameters_ to the following: `-functionAppProxyName {function-app-proxy-name}`
 
- 3. **Deploy API:** Use the _Azure App Service Deploy_ task, with the _App type_ set to `Function app`. Set the _App Service name_ to `contentreactor$(UniqueResourceNameSuffix)`. Set the _Package or folder_ to the relative location of the `.zip` file for the front-end API, e.g. `$(System.DefaultWorkingDirectory)/Web-CI/webapp/*.zip`.
+ 3. **Deploy API:** Use the _Azure App Service Deploy_ task, with the _App type_ set to `Function app`. Set the _App Service name_ to `crweb$(UniqueResourceNameSuffix)`. Set the _Package or folder_ to the relative location of the `.zip` file for the front-end API, e.g. `$(System.DefaultWorkingDirectory)/Web-CI/webapp/*.zip`.
 
  4. **Deploy Event Subscriptions ARM Template:** Use the _Azure Resource Group Deployment_ task, with the _Action_ set to `Create or update resource group`. Set the _Template_ to the location of the `eventGridSubscriptions.json` file, e.g. `$(System.DefaultWorkingDirectory)/web/deploy/eventGridSubscriptions.json`. Set the _Overridable template parameters_ to the following: `eventGridTopicName={event-grid-topic-name}  appServiceName={app-service-name}`
 

--- a/setup.md
+++ b/setup.md
@@ -357,7 +357,7 @@ The web app is deployed into its own resource group. It has its own ARM template
 
  2. **Deploy ARM Template:** Use the _Azure Resource Group Deployment_ task, with the _Action_ set to `Create or update resource group`. Set the _Template_ to the location of the `template.json` file, e.g. `$(System.DefaultWorkingDirectory)/web/deploy/template.json`. Set the _Overridable template parameters_ to the following: `-functionAppProxyName {function-app-proxy-name}`
 
- 3. **Deploy API:** Use the _Azure App Service Deploy_ task, with the _App type_ set to `Function app`. Set the _App Service name_ to `crweb$(UniqueResourceNameSuffix)`. Set the _Package or folder_ to the relative location of the `.zip` file for the front-end API, e.g. `$(System.DefaultWorkingDirectory)/Web-CI/webapp/*.zip`.
+ 3. **Deploy API:** Use the _Azure App Service Deploy_ task, with the _App type_ set to `Web App`. Set the _App Service name_ to `crweb$(UniqueResourceNameSuffix)`. Set the _Package or folder_ to the relative location of the `.zip` file for the front-end API, e.g. `$(System.DefaultWorkingDirectory)/Web-CI/webapp/*.zip`.
 
  4. **Deploy Event Subscriptions ARM Template:** Use the _Azure Resource Group Deployment_ task, with the _Action_ set to `Create or update resource group`. Set the _Template_ to the location of the `eventGridSubscriptions.json` file, e.g. `$(System.DefaultWorkingDirectory)/web/deploy/eventGridSubscriptions.json`. Set the _Overridable template parameters_ to the following: `eventGridTopicName={event-grid-topic-name}  appServiceName={app-service-name}`
 

--- a/web/build/build.yaml
+++ b/web/build/build.yaml
@@ -9,11 +9,19 @@ queue:
 
 steps:
 
-# Build Angular App
+# Install Angular App Dependencies
 - task: Npm@1
+  name: InstallNpmPackages
+  displayName: Install Angular App Dependencies
   inputs:
+    command: install
     workingDir: 'web/src/signalr-web/SignalRMiddleware/EventApp'
-    verbose: false
+    verbose: true
+
+# Package Angular App
+- script: npm run dist
+  displayName: Package Angular App
+  workingDirectory: 'web/src/signalr-web/SignalRMiddleware/EventApp'
 
 # Build the SignalR ASP.NET WebApp
 - task: DotNetCoreCLI@2

--- a/web/build/build.yaml
+++ b/web/build/build.yaml
@@ -3,7 +3,6 @@
 resources:
 - repo: self
 queue:
-  name: ContentReactor-Web-CI
   demands: 
   - npm
   - msbuild

--- a/web/src/signalr-web/SignalRMiddleware/EventApp/src/app/components/items/item.component.ts
+++ b/web/src/signalr-web/SignalRMiddleware/EventApp/src/app/components/items/item.component.ts
@@ -562,7 +562,7 @@ export class ItemComponent {
     
     }
     
-    openSubmitTextModal(content,textId:string) {
+    openSubmitTextModal(content) {
         this.inputText = ""
         this.modalService.open(content).result.then((result) => {        
             this.closeResult = `Closed with: ${result}`;

--- a/web/src/signalr-web/SignalRMiddleware/EventApp/src/environments/environment.prod.ts
+++ b/web/src/signalr-web/SignalRMiddleware/EventApp/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
 export const environment = {
-  production: true
+  production: true,
+  appInsights: { 
+    instrumentationKey: "%INSTRUMENTATION_KEY%" 
+  }
 };


### PR DESCRIPTION
## Purpose
I encountered several issues when trying to build and deploy the solution using VSTS.  In fixing them, I decided to simplify the deployment scripts to use a single globally unique prefix value and a naming convention that started with the resource groups.  

**I also updated the solution to use one instance of Application Insights with the hope that it's Application Map feature will help visualize the system once the Azure Functions team gets the dependencies working and AI.**

I updated all ARM templates and the documentation.  I also removed some unused ps1 scripts.

Below are the resources that will be created if you used 'serverlessstew' as your globally unique prefix.

|NAME|RESOURCE GROUP|TYPE|
|---|---|---|
|serverlessstew-audio-api|ServerlessStew-Audio|App Service|
|serverlessstew-audio-asp|ServerlessStew-Audio|App Service plan|
|serverlessstew-audio-cs|ServerlessStew-Audio|Cognitive Services|
|serverlessstew-audio-worker|ServerlessStew-Audio|App Service|
|serverlessstew-categories-api|ServerlessStew-Categories|App Service|
|serverlessstew-categories-asp|ServerlessStew-Categories|App Service plan|
|serverlessstew-categories-cs|ServerlessStew-Categories|Cognitive Services|
|serverlessstew-categories-db|ServerlessStew-Categories|Azure Cosmos DB account|
|serverlessstew-categories-worker|ServerlessStew-Categories|App Service|
|serverlessstew-events-topic|ServerlessStew-Events|Event Grid Topic|
|serverlessstew-images-api|ServerlessStew-Images|App Service|
|serverlessstew-images-asp|ServerlessStew-Images|App Service plan|
|serverlessstew-images-cs|ServerlessStew-Images|Cognitive Services|
|serverlessstew-images-worker|ServerlessStew-Images|App Service|
|serverlessstew-monitor-ai|ServerlessStew-Monitor|Application Insights|
|serverlessstew-proxy-api|ServerlessStew-Proxy|App Service|
|serverlessstew-proxy-asp|ServerlessStew-Proxy|App Service plan|
|serverlessstew-text-api|ServerlessStew-Text|App Service|
|serverlessstew-text-asp|ServerlessStew-Text|App Service plan|
|serverlessstew-text-db|ServerlessStew-Text|Azure Cosmos DB account|
|serverlessstew-web-app|ServerlessStew-Web|App Service|
|serverlessstew-web-asp-apps|ServerlessStew-Web|App Service plan|
|serverlessstewaudioblob|ServerlessStew-Audio|Storage account|
|serverlessstewimagesblob|ServerlessStew-Images|Storage account

Issue: #9 

## Does this introduce a breaking change?
```
[ X] Yes - I am working now to update the build scripts that were just merged.
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ X] Refactoring (no functional changes, no api changes)
[ X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the the setup.md steps for a VSTS build and deployment.

## What to Check
Verify that you do not get build or deployment errors and verify the app works after deployment.
