### PR TITLE
Updated the override parameters of Create or Update RG ( 2nd step in VSTS frontendDeployment Pipeline)

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -352,7 +352,7 @@ The web app is deployed into its own resource group. It has its own ARM template
 
  1. **Create Resource Name Suffix:** Use the _PowerShell_ task, with the _Script Path_ set to the relative location of the `CreateUniqueResourceNameSuffix.ps1` file, e.g. `$(System.DefaultWorkingDirectory)/Web-CI/deploy/CreateUniqueResourceNameSuffix.ps1`.
 
- 2. **Deploy ARM Template:** Use the _Azure Resource Group Deployment_ task, with the _Action_ set to `Create or update resource group`. Set the _Template_ to the location of the `template.json` file, e.g. `$(System.DefaultWorkingDirectory)/web/deploy/template.json`. Set the _Overridable template parameters_ to the following: `-functionAppProxyName {function-app-proxy-name}`
+ 2. **Deploy ARM Template:** Use the _Azure Resource Group Deployment_ task, with the _Action_ set to `Create or update resource group`. Set the _Template_ to the location of the `template.json` file, e.g. `$(System.DefaultWorkingDirectory)/web/deploy/template.json`. Set the _Overridable template parameters_ to the following: `-uniqueResourceNameSuffix $(UniqueResourceNameSuffix) -functionAppProxyName {function-app-proxy-name}`
 
  3. **Deploy API:** Use the _Azure App Service Deploy_ task, with the _App type_ set to `Web App`. Set the _App Service name_ to `crweb$(UniqueResourceNameSuffix)`. Set the _Package or folder_ to the relative location of the `.zip` file for the front-end API, e.g. `$(System.DefaultWorkingDirectory)/Web-CI/webapp/*.zip`.
 

--- a/web/src/signalr-web/SignalRMiddleware/SignalRMiddleware/SignalRMiddleware.csproj
+++ b/web/src/signalr-web/SignalRMiddleware/SignalRMiddleware/SignalRMiddleware.csproj
@@ -9,22 +9,22 @@
   <ItemGroup>
     <Compile Remove="event-app\**" />
     <Compile Remove="EventApp\**" />
+    <Compile Remove="wwwroot\**" />
     <Content Remove="event-app\**" />
     <Content Remove="EventApp\**" />
+    <Content Remove="wwwroot\**" />
     <EmbeddedResource Remove="event-app\**" />
     <EmbeddedResource Remove="EventApp\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
     <None Remove="event-app\**" />
     <None Remove="EventApp\**" />
+    <None Remove="wwwroot\**" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
   </ItemGroup>
 
   <!--<Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/web/src/signalr-web/SignalRMiddleware/SignalRMiddleware/SignalRMiddleware.csproj
+++ b/web/src/signalr-web/SignalRMiddleware/SignalRMiddleware/SignalRMiddleware.csproj
@@ -9,22 +9,22 @@
   <ItemGroup>
     <Compile Remove="event-app\**" />
     <Compile Remove="EventApp\**" />
-    <Compile Remove="wwwroot\**" />
     <Content Remove="event-app\**" />
     <Content Remove="EventApp\**" />
-    <Content Remove="wwwroot\**" />
     <EmbeddedResource Remove="event-app\**" />
     <EmbeddedResource Remove="EventApp\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
     <None Remove="event-app\**" />
     <None Remove="EventApp\**" />
-    <None Remove="wwwroot\**" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
   </ItemGroup>
 
   <!--<Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
The override parameters of Create or Update RG ( 2nd step in VSTS frontendDeployment Pipeline) is updated to include uniqueresourcename suffix global  variable 
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->


1. * According to setup.md the Deploy API  ( 3rd step in VSTS front end pipeline ) is attempting to deploy the artifacts to the AppService resource with the globalsuffix

2. * But the Previous step is creating resources without the global suffix and therefore will fail. So the Setup Documentation is Updated in step 2 to include global suffix to protect the occurrence of this situation

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

