### PR TITLE
Resolving Breaking Changes in Deployment

### DIFF
--- a/audio/deploy/microservice.json
+++ b/audio/deploy/microservice.json
@@ -31,7 +31,7 @@
         "blobAccountName": "[concat(variables('resourceNamePrefix'), 'blob', parameters('uniqueResourceNameSuffix'))]",
 
         "cognitiveServicesAccountName": "[concat(variables('resourceNamePrefix'), 'cs', parameters('uniqueResourceNameSuffix'))]",
-        "cognitiveServicesApiUrl": "https://speech.platform.bing.com/speech/recognition/interactive/cognitiveservices/v1?language=en-us&format=detailed",
+        "cognitiveServicesApiUrl": "https://westeurope.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1&format=detailed",
         
         "eventGridTopicResourceId": "[resourceId(parameters('eventsResourceGroupName'), 'Microsoft.EventGrid/topics', parameters('eventGridTopicName'))]"
     },

--- a/audio/deploy/microservice.json
+++ b/audio/deploy/microservice.json
@@ -184,7 +184,7 @@
             "sku": {
                 "name": "S0"
             },
-            "kind": "Bing.Speech",
+            "kind": "Speech",
             "properties": {}
         }
     ]

--- a/audio/deploy/microservice.json
+++ b/audio/deploy/microservice.json
@@ -119,7 +119,8 @@
                         "CognitiveServicesSpeechApiKey": "[listKeys(variables('cognitiveServicesAccountName'),'2016-02-01-preview').key1]",
                         "EventGridTopicEndpoint": "[reference(variables('eventGridTopicResourceId'), '2018-01-01').endpoint]",
                         "EventGridTopicKey": "[listKeys(variables('eventGridTopicResourceId'), '2018-01-01').key1]",
-                        "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]"
+                        "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsApiAppName'))]",
@@ -159,7 +160,8 @@
                         "CognitiveServicesSpeechApiKey": "[listKeys(variables('cognitiveServicesAccountName'),'2016-02-01-preview').key1]",
                         "EventGridTopicEndpoint": "[reference(variables('eventGridTopicResourceId'), '2018-01-01').endpoint]",
                         "EventGridTopicKey": "[listKeys(variables('eventGridTopicResourceId'), '2018-01-01').key1]",
-                        "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]"
+                        "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsWorkerApiAppName'))]",

--- a/audio/deploy/microservice.json
+++ b/audio/deploy/microservice.json
@@ -179,12 +179,12 @@
         {
             "name": "[variables('cognitiveServicesAccountName')]",
             "type": "Microsoft.CognitiveServices/accounts",
-            "location": "global",
+            "location": "[resourceGroup().location]",
             "apiVersion": "2016-02-01-preview",
             "sku": {
                 "name": "S0"
             },
-            "kind": "Speech",
+            "kind": "SpeechServices",
             "properties": {}
         }
     ]

--- a/audio/deploy/microservice.json
+++ b/audio/deploy/microservice.json
@@ -16,7 +16,7 @@
 
         "applicationInsightsLocation": {
             "type": "string",
-            "defaultValue": "westus2"
+            "defaultValue": "[resourceGroup().location]"
         }
     },
     "variables": {

--- a/categories/deploy/microservice.json
+++ b/categories/deploy/microservice.json
@@ -149,7 +149,8 @@
                         "CognitiveServicesSearchApiEndpoint": "[variables('cognitiveServicesSearchApiUrl')]",
                         "CognitiveServicesSearchApiKey": "[listKeys(variables('cognitiveServicesAccountName'),'2016-02-01-preview').key1]",
                         "BigHugeThesaurusApiEndpoint": "[variables('bigHugeThesaurusApiUrl')]",
-                        "BigHugeThesaurusApiKey": "[parameters('bigHugeThesaurusApiKey')]"
+                        "BigHugeThesaurusApiKey": "[parameters('bigHugeThesaurusApiKey')]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsWorkerApiAppName'))]",

--- a/categories/deploy/microservice.json
+++ b/categories/deploy/microservice.json
@@ -14,11 +14,6 @@
             "type": "string"
         },
 
-        "applicationInsightsLocation": {
-            "type": "string",
-            "defaultValue": "westus2"
-        },
-
         "bigHugeThesaurusApiKey": {
             "type": "string",
             "defaultValue": ""
@@ -48,7 +43,7 @@
             "name": "[variables('applicationInsightsName')]",
             "type": "Microsoft.Insights/components",
             "apiVersion": "2014-04-01",
-            "location": "[parameters('applicationInsightsLocation')]",
+            "location": "[resourceGroup().location]",
             "kind": "other",
             "properties": {
                 "applicationId": "[variables('applicationInsightsName')]"

--- a/categories/deploy/microservice.json
+++ b/categories/deploy/microservice.json
@@ -104,7 +104,8 @@
                         "CognitiveServicesSearchApiEndpoint": "[variables('cognitiveServicesSearchApiUrl')]",
                         "CognitiveServicesSearchApiKey": "[listKeys(variables('cognitiveServicesAccountName'),'2016-02-01-preview').key1]",
                         "BigHugeThesaurusApiEndpoint": "[variables('bigHugeThesaurusApiUrl')]",
-                        "BigHugeThesaurusApiKey": "[parameters('bigHugeThesaurusApiKey')]"
+                        "BigHugeThesaurusApiKey": "[parameters('bigHugeThesaurusApiKey')]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsApiAppName'))]",

--- a/images/deploy/microservice.json
+++ b/images/deploy/microservice.json
@@ -16,7 +16,7 @@
 
         "applicationInsightsLocation": {
             "type": "string",
-            "defaultValue": "westus2"
+            "defaultValue": "[resourceGroup().location]"
         }
     },
     "variables": {
@@ -117,7 +117,8 @@
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('applicationInsightsName')), '2014-04-01').InstrumentationKey]",
                         "EventGridTopicEndpoint": "[reference(variables('eventGridTopicResourceId'), '2018-01-01').endpoint]",
                         "EventGridTopicKey": "[listKeys(variables('eventGridTopicResourceId'), '2018-01-01').key1]",
-                        "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]"
+                        "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsApiAppName'))]",
@@ -157,7 +158,8 @@
                         "EventGridTopicKey": "[listKeys(variables('eventGridTopicResourceId'), '2018-01-01').key1]",
                         "BlobConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('blobAccountName'), ';AccountKey=', listKeys(variables('blobAccountName'),'2015-05-01-preview').key1)]",
                         "CognitiveServicesVisionApiEndpoint": "[reference(variables('cognitiveServicesAccountName'),'2016-02-01-preview').endpoint]",
-                        "CognitiveServicesVisionApiKey": "[listKeys(variables('cognitiveServicesAccountName'),'2016-02-01-preview').key1]"
+                        "CognitiveServicesVisionApiKey": "[listKeys(variables('cognitiveServicesAccountName'),'2016-02-01-preview').key1]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsWorkerApiAppName'))]",

--- a/text/deploy/microservice.json
+++ b/text/deploy/microservice.json
@@ -16,7 +16,7 @@
 
         "applicationInsightsLocation": {
             "type": "string",
-            "defaultValue": "westus2"
+            "defaultValue": "[resourceGroup().location]"
         }
     },
     "variables": {
@@ -95,7 +95,8 @@
                         "CosmosDBAccountEndpointUrl": "[reference(variables('cosmosDbAccountName')).documentEndpoint]",
                         "CosmosDBAccountKey": "[listKeys(variables('cosmosDbAccountName'), '2015-04-08').primaryMasterKey]",
                         "DatabaseName": "[variables('cosmosDbDatabaseName')]",
-                        "CollectionName": "[variables('cosmosDbCollectionName')]"
+                        "CollectionName": "[variables('cosmosDbCollectionName')]",
+                        "AzureWebJobsSecretStorageType":"Files"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('functionsApiAppName'))]",

--- a/web/deploy/template.json
+++ b/web/deploy/template.json
@@ -11,7 +11,7 @@
       },
       "applicationInsightsLocation": {
         "type": "string",
-        "defaultValue": "westus2"
+        "defaultValue": "[resourceGroup().location]"
       },
       "appServicePlanSkuName": {
         "type": "string",
@@ -97,7 +97,8 @@
                 },
                 "properties": {
                     "FUNCTION_API_PROXY_ROOT": "[variables('functionAppProxyUrl')]",
-                    "WEBSITE_NODE_DEFAULT_VERSION" : "6.9.1"
+                    "WEBSITE_NODE_DEFAULT_VERSION" : "6.9.1",
+                    "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('applicationInsightsName')), '2014-04-01').InstrumentationKey]"
                 }
             }
         ],

--- a/web/src/signalr-web/SignalRMiddleware/EventApp/src/environments/environment.prod.ts
+++ b/web/src/signalr-web/SignalRMiddleware/EventApp/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
   appInsights: { 
-    instrumentationKey: "%INSTRUMENTATION_KEY%" 
+    instrumentationKey: "3e0ab8f5-c675-448c-8a15-08ba5ec45317" /*The web middleware should return the key to the Angular Environment*/
   }
 };

--- a/web/src/signalr-web/SignalRMiddleware/EventApp/src/environments/environment.ts
+++ b/web/src/signalr-web/SignalRMiddleware/EventApp/src/environments/environment.ts
@@ -6,6 +6,6 @@
 export const environment = {
   production: false,
   appInsights: { 
-    instrumentationKey: "%INSTRUMENTATION_KEY%" 
+    instrumentationKey: "3e0ab8f5-c675-448c-8a15-08ba5ec45317" 
   }
 };


### PR DESCRIPTION
## Purpose
Resolving breaking changes in ARM Templates due to Function Runtime Upgrade to ~V2

- Function Runtime ~2.0 secrets are stored in blobs instead of Files. But ARM Template function `listsecrets ` function does not support this resulting in broken deployment Pipeline. As an Intermediate solution the Function API and Worker API are adjusted to maintain Secrets in File System ( Since we do not use slots, this is not hurting our Implementation )

Read More about this Issue [here](https://github.com/Azure/azure-functions-host/issues/3411)

- Removed HardCoded Location Value for Application Insights Resource since the service is available in almost all regions. This is now adjusted to fetch the resource group location

- Added SpeechServies instead of Bing.Speech to ARM Template since this is no longer supported and will be phased out from October 2019 

Read more about this situation [Here](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-migrate-from-bing-speech)

- Added Application Insights Instrumentation Key to the Appsettings of the Middleware Service to track Server Level Telemetry

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```